### PR TITLE
Remove calls to stop service

### DIFF
--- a/packaging/postrm.sh
+++ b/packaging/postrm.sh
@@ -37,11 +37,9 @@ elif [[ -f /etc/debian_version ]]; then
       which systemctl &>/dev/null
       if [[ $? -eq 0 ]]; then
           disable_systemd
-          deb-systemd-invoke stop amonagent.service
       else
           # Assuming sysv
           disable_update_rcd
-          invoke-rc.d amonagent stop
       fi
     fi
 fi


### PR DESCRIPTION
It looks like the packing/prerm.sh handles stopping the service so it shouldn't need to be called here as well.
If you try to remove this package you get the following error because it's trying to stop a service after the systemd or sysv scripts are removed leaving the package in a half-installed state.

```
Removing amonagent (1:0.7.2) ...
Removed symlink /etc/systemd/system/multi-user.target.wants/amonagent.service.
Removed symlink /etc/systemd/system/amonagent.service.
Failed to stop amonagent.service: Unit amonagent.service not loaded.
dpkg: error processing package amonagent (--remove):
 subprocess installed post-removal script returned error exit status 5
Errors were encountered while processing:
 amonagent
E: Sub-process /usr/bin/dpkg returned an error code (1)
```