### PR TITLE
Fix #17 - Amon Agent Stops Sending Data

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -165,7 +165,6 @@ func (a *Agent) Run(shutdown chan struct{}, debug bool) error {
 	log.Infof("Agent Config: Interval:%s\n", a.Interval)
 
 	ticker := time.NewTicker(a.Interval)
-	defer ticker.Stop()
 
 	for _, p := range a.ConfiguredPlugins {
 
@@ -182,14 +181,16 @@ func (a *Agent) Run(shutdown chan struct{}, debug bool) error {
 	}
 
 	for {
-		if err := a.GatherAndSend(debug); err != nil {
-			log.Infof("Can not collect and send metrics, exiting: %s\n", err.Error())
-		}
 		select {
 		case <-shutdown:
+			log.Info("Shutting down Amon Agent")
+			ticker.Stop()
+
 			return nil
 		case <-ticker.C:
-			continue
+			if err := a.GatherAndSend(debug); err != nil {
+				log.Infof("Can not collect and send metrics, exiting: %s\n", err.Error())
+			}
 		}
 	}
 }

--- a/agent.go
+++ b/agent.go
@@ -165,6 +165,7 @@ func (a *Agent) Run(shutdown chan struct{}, debug bool) error {
 	log.Infof("Agent Config: Interval:%s\n", a.Interval)
 
 	ticker := time.NewTicker(a.Interval)
+	defer ticker.Stop()
 
 	for _, p := range a.ConfiguredPlugins {
 
@@ -181,16 +182,16 @@ func (a *Agent) Run(shutdown chan struct{}, debug bool) error {
 	}
 
 	for {
+		if err := a.GatherAndSend(debug); err != nil {
+			log.Infof("Can not collect and send metrics, exiting: %s\n", err.Error())
+		}
+
 		select {
 		case <-shutdown:
 			log.Info("Shutting down Amon Agent")
-			ticker.Stop()
-
 			return nil
 		case <-ticker.C:
-			if err := a.GatherAndSend(debug); err != nil {
-				log.Infof("Can not collect and send metrics, exiting: %s\n", err.Error())
-			}
+			continue
 		}
 	}
 }

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -17,6 +18,11 @@ import (
 var DefaultTimeOut = 10 * time.Second
 
 var tr = &http.Transport{
+	Dial: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial,
+	TLSHandshakeTimeout:   DefaultTimeOut,
 	ResponseHeaderTimeout: DefaultTimeOut,
 	TLSClientConfig:       &tls.Config{InsecureSkipVerify: true}, // for self-signed certificates
 }

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -54,6 +54,10 @@ func SendData(data interface{}, debug bool) error {
 	})
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(JSONBytes))
+	if err != nil {
+		return fmt.Errorf("Can't create request to Amon API %s\n", err.Error())
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Cancel = cancel
 

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -48,8 +48,14 @@ func SendData(data interface{}, debug bool) error {
 		out.WriteTo(os.Stdout)
 	}
 
+	cancel := make(chan struct{})
+	time.AfterFunc(DefaultTimeOut, func() {
+		close(cancel)
+	})
+
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(JSONBytes))
 	req.Header.Set("Content-Type", "application/json")
+	req.Cancel = cancel
 
 	client := &http.Client{Transport: tr}
 	resp, err := client.Do(req)

--- a/internal/settings/paths_osx.go
+++ b/internal/settings/paths_osx.go
@@ -1,0 +1,6 @@
+// +build darwin
+
+package settings
+
+// ConfigPath - XXX
+const ConfigPath = "/etc/opt/amonagent/"

--- a/internal/settings/paths_osx.go
+++ b/internal/settings/paths_osx.go
@@ -1,6 +1,0 @@
-// +build darwin
-
-package settings
-
-// ConfigPath - XXX
-const ConfigPath = "/etc/opt/amonagent/"


### PR DESCRIPTION
Fix #17 

Implemented a request cancel policy which will automatically cancel the http request if it exceeds 10 seconds. Also updated remote.go to include additional timeouts on the http.Client connection. These were added to prevent the scenario when an http request is made but never returns; this condition would leave the Amon Agent in a state where it would not collect or send new data, even after the issue causing the http request to hang had been resolved.

This implementation should log the error and continue to re-attempt the collection and sending of data with minimal delay or impact.